### PR TITLE
Use 'href' instead of :href in `present`

### DIFF
--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -212,7 +212,7 @@ class Jsonite
     self.class.links.each_with_object({}) do |(rel, link), links|
       catch :ignore do
         href = resource.instance_exec context, &link[:handler]
-        links[rel.to_s] = { href: href }.merge link.except :handler
+        links[rel.to_s] = { 'href' => href }.merge link.except :handler
       end
     end
   end


### PR DESCRIPTION
Jsonite consistently uses string keys in the presentation methods except
for the `:href` key in links. This comes through as a symbol which,
before calling #to_json, is fine. However, this breaks expectations
given that all other hash keys are strings. We should keep this
consistent and change this key to be a string as well.

Signed-off-by: David Celis me@davidcel.is
