### PR TITLE
Root key configuration

### DIFF
--- a/lib/jsonite/helper.rb
+++ b/lib/jsonite/helper.rb
@@ -10,6 +10,8 @@ class Jsonite
         resource.model_name.collection
       elsif resource.class.respond_to? :model_name
         resource.class.model_name.singular
+      else
+        resource.class.name.underscore
       end
     end
 

--- a/spec/benchmark_spec.rb
+++ b/spec/benchmark_spec.rb
@@ -27,6 +27,9 @@ describe 'Jsonite performance' do
   end
 
   it 'presents hundreds of objects very quickly' do
+    # rehearsal
+    10.times { UserPresenter.present(users).as_json }
+
     time = Benchmark.realtime do |x|
       # 175 * 10 times = 1750 total presentations
       10.times { UserPresenter.present(users).as_json }

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -30,6 +30,38 @@ describe Jsonite do
       expect(presented).to eq "name"=>"Stephen"
     end
 
+    context 'root: true' do
+
+      it 'wraps the resource in a root key derived from the resource class' do
+        presented = presenter.present resource, root: true
+        expect(presented).to eq "open_struct"=>{"name"=>"Stephen"}
+      end
+
+    end
+
+    context 'root: String' do
+
+      it 'wraps the resource in the given root key' do
+        presented = presenter.present resource, root: 'user'
+        expect(presented).to eq "user"=>{"name"=>"Stephen"}
+      end
+
+    end
+
+  end
+
+  describe '.defaults' do
+
+    it 'sets a hash of options to be used when presenting' do
+      presenter = Class.new Jsonite do
+        defaults root: 'user'
+        property :name
+      end
+      presented = presenter.new OpenStruct.new(name: 'Stephen')
+      json = presented.to_json
+      expect(json).to eq '{"user":{"name":"Stephen"}}'
+    end
+
   end
 
   describe ".property" do
@@ -280,6 +312,20 @@ describe Jsonite do
       presented_user = user_presenter.present user
       json = presented_user.to_json
       expect(json).to eq '{"_embedded":{"best_friend":null}}'
+    end
+
+  end
+
+  describe '.include_root_in_json' do
+
+    it 'wraps presentations in a root key derived from the resource class' do
+      Jsonite.stub(include_root_in_json: true)
+      presenter = Class.new Jsonite do
+        property :name
+      end
+      presented = presenter.new OpenStruct.new(name: 'Stephen')
+      json = presented.to_json
+      expect(json).to eq '{"open_struct":{"name":"Stephen"}}'
     end
 
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -8,6 +8,8 @@ Document = Struct.new(:name, :path, :content_type, :related_documents) do
 end
 
 class DocumentPresenter < Jsonite
+  defaults root: true
+
   property :name
   property :path
   property :content_type
@@ -26,6 +28,8 @@ User = Struct.new(:name, :age, :friends, :documents) do
 end
 
 class UserPresenter < Jsonite
+  defaults root: true
+
   property :name
   property :age
   property(:location) { '37.788079, -122.401288' }


### PR DESCRIPTION
Right now, the JSON generated always has a root key. This should be configurable for APIs that don't want to pass `root: nil` everywhere.

It may need 3 level of configuration:
- on: Always have a root key
- off: Never have a root key
- auto: Have a root key for collections
