### PR TITLE
Stringify all keys passed to options in `embed`

### DIFF
--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/hash/keys'
 require 'active_support/json/encoding'
 require 'jsonite/helper'
 
@@ -106,7 +107,7 @@ class Jsonite
     #   #   }
     #   # }
     def link rel = :self, options = {}, &handler
-      links[rel.to_s] = { handler: Proc.new }.merge options # require handler
+      links[rel.to_s] = { handler: Proc.new }.merge options.deep_stringify_keys
     end
 
     def links


### PR DESCRIPTION
I previously submitted a patch that stringified the `:href` when
creating links thinking that other options passed were also stringified
during presentation. However, they were actually all left as symbols. To
maintain consistency and expectations with how Jsonite presents an
object as a whole, we should stringify all keys when possible.

Signed-off-by: David Celis me@davidcel.is
