### PR TITLE
WIP: Ignore enhancement

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,10 @@ rescue LoadError
 end
 
 task default: defaults
+
+task :loc do
+  print '  lib   '
+  puts `zsh -c "grep -vE '^ *#|^$' lib/**/*.rb | wc -l"`.strip
+  print '  spec  '
+  puts `zsh -c "grep -vE '^ *#|^$' spec/**/*.rb | wc -l"`.strip
+end

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -90,7 +90,7 @@ class Jsonite
     #   than in the <tt>_embedded</tt> node).
     # * <tt>:ignore_nil</tt> - Ignore `nil`.
     def property name, type = nil, **options, &handler
-      properties[name.to_s] = { type: type, handler: handler }.merge options
+      properties[name] = { type: type, handler: handler }.merge options
     end
 
     def properties *properties
@@ -137,7 +137,7 @@ class Jsonite
     #   #   }
     #   # }
     def link rel = :self, options = {}, &handler
-      links[rel.to_s] = { handler: Proc.new }.merge options # require handler
+      links[rel] = { handler: Proc.new }.merge options # require handler
     end
 
     def links
@@ -168,7 +168,7 @@ class Jsonite
     # * <tt>:ignore_nil</tt> - Ignore `nil`.
     def embed rel, **options, &handler
       options.fetch :with unless handler
-      embedded[rel.to_s] = { handler: handler }.merge options
+      embedded[rel] = { handler: handler }.merge options
     end
 
     def embedded

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -52,7 +52,7 @@ class Jsonite
       root ? { root => presented } : presented
     end
 
-    # Sets a default presenter for a given resource class.
+    # Sets the current presenter as the default for a given resource class.
     #
     #   class UserPresenter < Jsonite
     #     presents User
@@ -62,6 +62,17 @@ class Jsonite
     #   # => {"email"=>"stephen@example.com"}
     def presents resource_class
       @@mapping[resource_class] = self
+    end
+
+    # Returns the resource class registered to the current presenter.
+    #
+    #   class UserPresenter < Jsonite(User)
+    #     property :email
+    #   end
+    #   UserPresenter.resource_class
+    #   # => User
+    def resource_class
+      @@mapping.invert[self]
     end
 
     # Defines a property to be exposed during presentation.
@@ -175,9 +186,7 @@ class Jsonite
     private
 
     def inherited subclass
-      if name.nil? and resource_class = @@mapping.invert[self]
-        subclass.presents resource_class
-      end
+      subclass.presents resource_class if name.nil? && resource_class
 
       subclass.properties.update properties
       subclass.links.update links

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -105,7 +105,8 @@ class Jsonite
     # * <tt>:with</tt> - A specified presenter. Ignored when a handler is
     #   present. Useful when you want to embed a resource as a property (rather
     #   than in the <tt>_embedded</tt> node).
-    # * <tt>:ignore_nil</tt> - Ignore `nil`.
+    # * <tt>:ignore</tt> - Don't include the property in the payload if the
+    #   given symbol sent or proc called returns true.
     #
     # All other options are stored on the presenter class's properties hash,
     # which could be used, for example, to generate documentation.
@@ -200,7 +201,8 @@ class Jsonite
     # Configuration options:
     # * <tt>:with</tt> - A specified presenter. Required if a handler isn't
     #   present.
-    # * <tt>:ignore_nil</tt> - Ignore `nil`.
+    # * <tt>:ignore</tt> - Don't include the resource in the payload if the
+    #   given symbol sent or proc called returns true.
     def embed rel, **options, &handler
       options.fetch :with unless handler
       embedded[rel] = { handler: handler }.merge options
@@ -289,7 +291,9 @@ class Jsonite
       resource.send name
     end
 
-    throw :ignore if options[:ignore_nil] && value.nil?
+    if options[:ignore]
+      throw :ignore if value.instance_exec context, &options[:ignore].to_proc
+    end
 
     if options[:with] && !value.nil?
       return options[:with].present value, context: context, root: nil

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -223,7 +223,7 @@ class Jsonite
     options = defaults.merge options
 
     context = options.delete :context
-    presented = properties(context)
+    presented = properties context
     _links = links context
     presented['_links'] = _links if _links.present?
     _embedded = embedded context

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -9,7 +9,11 @@ require 'jsonite/helper'
 # http://tools.ietf.org/html/draft-kelly-json-hal-05
 class Jsonite
 
-  @@mapping = {}
+  @@mapping = Hash.new do |mapping, key|
+    if ancestor = key.ancestors.find { |a| mapping.key? a }
+      mapping[key] = mapping[ancestor]
+    end
+  end
 
   class << self
 

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -193,14 +193,6 @@ class Jsonite
       @embedded ||= {}
     end
 
-    def let name, &handler
-      lets[name.to_s] = handler
-    end
-
-    def lets
-      @lets ||= {}
-    end
-
     private
 
     def inherited subclass

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -27,7 +27,7 @@ class Jsonite
     # * <tt>:with</tt> - A specified presenter (defaults to `self`).
     #
     # All other options are passed along to <tt>#present</tt>.
-    def present resource, options = {}
+    def present resource, **options
       presenter = options.delete(:with) { self }
 
       presented = if resource.is_a? Jsonite
@@ -58,7 +58,7 @@ class Jsonite
     #   present. Useful when you want to embed a resource as a property (rather
     #   than in the <tt>_embedded</tt> node).
     # * <tt>:ignore_nil</tt> - Ignore `nil`.
-    def property name, options = {}, &handler
+    def property name, **options, &handler
       properties[name.to_s] = { handler: handler }.merge options
     end
 
@@ -135,7 +135,7 @@ class Jsonite
     # * <tt>:with</tt> - A specified presenter. Required if a handler isn't
     #   present.
     # * <tt>:ignore_nil</tt> - Ignore `nil`.
-    def embed rel, options = {}, &handler
+    def embed rel, **options, &handler
       options.fetch :with unless handler
       embedded[rel.to_s] = { handler: handler }.merge options
     end

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -9,6 +9,8 @@ require 'jsonite/helper'
 # http://tools.ietf.org/html/draft-kelly-json-hal-05
 class Jsonite
 
+  @@mapping = {}
+
   class << self
 
     # Presents a resource (or array of resources).
@@ -28,20 +30,33 @@ class Jsonite
     #
     # All other options are passed along to <tt>#present</tt>.
     def present resource, **options
-      presenter = options.delete(:with) { self }
-
       presented = if resource.is_a? Jsonite
         resource.present options
       elsif resource.respond_to? :to_ary
         resource = resource.to_ary.map do |member|
-          presenter.new(member).present options.merge root: nil
+          present member, options.merge(root: nil)
         end
       else
+        presenter = options.fetch :with do
+          self == Jsonite and @@mapping[resource.class] or self
+        end
         presenter.new(resource).present options.merge root: nil
       end
 
       root = options.fetch(:root) { Helper.resource_name resource }
       root ? { root => presented } : presented
+    end
+
+    # Sets a default presenter for a given resource class.
+    #
+    #   class UserPresenter < Jsonite
+    #     presents User
+    #     property :email
+    #   end
+    #   Jsonite.present(User.first)
+    #   # => {"email"=>"stephen@example.com"}
+    def presents resource_class
+      @@mapping[resource_class] = self
     end
 
     # Defines a property to be exposed during presentation.

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -263,6 +263,11 @@ class Jsonite
 
 end
 
+# Returns a new Jsonite subclass that presents the given resource class.
+#
+#   class UserPresenter < Jsonite(User)
+#     property :name
+#   end
 def Jsonite resource_class
   Class.new(Jsonite).tap { |presenter| presenter.presents resource_class }
 end

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -17,6 +17,22 @@ class Jsonite
 
   class << self
 
+    # Configures whether root keys are automatically derived from
+    # resource classes during presentation. Can be overrided.
+    #
+    # Jsonite.include_root_in_json = true
+    #
+    # Defaults to ActiveRecord::Base.include_root_in_json, or false
+    # if ActiveRecord isn't defined.
+    attr_writer :include_root_in_json
+
+    def include_root_in_json
+      return @include_root_in_json if defined? @include_root_in_json
+
+      @include_root_in_json = defined?(ActiveRecord) && \
+        ActiveRecord::Base.include_root_in_json
+    end
+
     # Presents a resource (or array of resources).
     #
     #   class UserPresenter < Jsonite
@@ -48,7 +64,8 @@ class Jsonite
         presenter.new(resource).present options.merge root: nil
       end
 
-      root = options.fetch(:root) { Helper.resource_name resource }
+      root = options.fetch :root, Jsonite.include_root_in_json
+      root = Helper.resource_name resource if root == true
       root ? { root => presented } : presented
     end
 
@@ -229,7 +246,8 @@ class Jsonite
     _embedded = embedded context
     presented['_embedded'] = _embedded if _embedded.present?
 
-    root = options.fetch(:root) { Helper.resource_name(resource) }
+    root = options.fetch :root, Jsonite.include_root_in_json
+    root = Helper.resource_name resource if root == true
     root ? { root => presented } : presented
   end
 

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -44,6 +44,7 @@ class Jsonite
         presenter = options.fetch :with do
           self == Jsonite and @@mapping[resource.class] or self
         end
+        return resource if presenter == Jsonite
         presenter.new(resource).present options.merge root: nil
       end
 

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -73,8 +73,8 @@ class Jsonite
     #   present. Useful when you want to embed a resource as a property (rather
     #   than in the <tt>_embedded</tt> node).
     # * <tt>:ignore_nil</tt> - Ignore `nil`.
-    def property name, **options, &handler
-      properties[name.to_s] = { handler: handler }.merge options
+    def property name, type = nil, **options, &handler
+      properties[name.to_s] = { type: type, handler: handler }.merge options
     end
 
     def properties *properties

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -169,10 +169,14 @@ class Jsonite
 
     private
 
-    def inherited presenter
-      presenter.properties.update properties
-      presenter.links.update links
-      presenter.embedded.update embedded
+    def inherited subclass
+      if name.nil? and resource_class = @@mapping.invert[self]
+        subclass.presents resource_class
+      end
+
+      subclass.properties.update properties
+      subclass.links.update links
+      subclass.embedded.update embedded
     end
 
   end
@@ -252,4 +256,8 @@ class Jsonite
     value
   end
 
+end
+
+def Jsonite resource_class
+  Class.new(Jsonite).tap { |presenter| presenter.presents resource_class }
 end

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -32,7 +32,7 @@ class Jsonite
 
       presented = if resource.is_a? Jsonite
         resource.present options
-      elsif resource.respond_to?(:to_ary)
+      elsif resource.respond_to? :to_ary
         resource = resource.to_ary.map do |member|
           presenter.new(member).present options.merge root: nil
         end
@@ -40,7 +40,7 @@ class Jsonite
         presenter.new(resource).present options.merge root: nil
       end
 
-      root = options.fetch(:root) { Helper.resource_name(resource) }
+      root = options.fetch(:root) { Helper.resource_name resource }
       root ? { root => presented } : presented
     end
 

--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -89,6 +89,24 @@ class Jsonite
     #   present. Useful when you want to embed a resource as a property (rather
     #   than in the <tt>_embedded</tt> node).
     # * <tt>:ignore_nil</tt> - Ignore `nil`.
+    #
+    # All other options are stored on the presenter class's properties hash,
+    # which could be used, for example, to generate documentation.
+    #
+    #   class UserPresenter < Jsonite
+    #     property :email, type: String
+    #   end
+    #   UserPresenter.properties[:email][:type]
+    #   # => String
+    #
+    # As a shorthand, type can also be documented if passed as the second
+    # argument.
+    #
+    #   class UserPresenter < Jsonite
+    #     property :email, String
+    #   end
+    #   UserPresenter.properties[:email][:type]
+    #   # => String
     def property name, type = nil, **options, &handler
       properties[name] = { type: type, handler: handler }.merge options
     end

--- a/lib/jsonite/helper.rb
+++ b/lib/jsonite/helper.rb
@@ -10,6 +10,8 @@ class Jsonite
         resource.model_name.collection
       elsif resource.class.respond_to? :model_name
         resource.class.model_name.singular
+      else
+        resource.class.name.underscore
       end
     end
 

--- a/spec/benchmark_spec.rb
+++ b/spec/benchmark_spec.rb
@@ -27,6 +27,9 @@ describe 'Jsonite performance' do
   end
 
   it 'presents hundreds of objects very quickly' do
+    # rehearsal
+    10.times { UserPresenter.present(users).as_json }
+
     time = Benchmark.realtime do |x|
       # 175 * 10 times = 1750 total presentations
       10.times { UserPresenter.present(users).as_json }

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -35,9 +35,7 @@ describe Jsonite do
   describe ".presents" do
 
     before do
-      type = resource_class
-      Class.new Jsonite do
-        presents type
+      Class.new(Jsonite(resource_class)) do
         property :name
       end
     end

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -32,6 +32,34 @@ describe Jsonite do
 
   end
 
+  describe ".presents" do
+
+    before do
+      type = resource_class
+      Class.new Jsonite do
+        presents type
+        property :name
+      end
+    end
+
+    let :resource_class do
+      Class.new OpenStruct
+    end
+
+    let :resource do
+      resource_class.new name: 'Stephen', age: 30
+    end
+
+    it "sets a default presenter for a given resource class" do
+      presented = Jsonite.present resource
+      expect(presented).to eq "name"=>"Stephen"
+
+      presented = Jsonite.present [resource, resource]
+      expect(presented).to eq [{"name"=>"Stephen"}, {"name"=>"Stephen"}]
+    end
+
+  end
+
   describe ".property" do
 
     it "exposes a specified attribute when presenting an object" do

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -118,6 +118,13 @@ describe Jsonite do
       expect(json).to eq '{"name":"Stephen"}'
     end
 
+    it "tracks additional information about an attribute" do
+      presenter = Class.new Jsonite do
+        property :name, String, foo: 'bar'
+      end
+      expect(presenter.properties[:name]).to include :type=>String, :foo=>"bar"
+    end
+
     it "evaluates a property block in the context of the presented object" do
       presenter = Class.new Jsonite do
         property :screamed_name do

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -56,6 +56,12 @@ describe Jsonite do
       expect(presented).to eq [{"name"=>"Stephen"}, {"name"=>"Stephen"}]
     end
 
+    it "presents resource subclasses" do
+      subclass = Class.new resource_class
+      presented = Jsonite.present subclass.new name: 'Stephen', age: 30
+      expect(presented).to eq "name"=>"Stephen"
+    end
+
   end
 
   describe ".property" do

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -301,7 +301,7 @@ describe Jsonite do
       expect(json).to eq '{}'
     end
 
-    it "allows nil embeds", focus: true do
+    it "allows nil embeds" do
       user_presenter = Class.new Jsonite
       user_presenter.embed :best_friend, with: user_presenter
       user = OpenStruct.new

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -5,29 +5,46 @@ describe Jsonite do
 
   describe ".present" do
 
-    let :presenter do
-      Class.new Jsonite do
-        property :name
+    context "a hash" do
+
+      let :resource do
+        {"name"=>"Stephen"}
       end
+
+      it "passes through unmodified" do
+        presented = Jsonite.present resource
+        expect(presented).to eq resource
+      end
+
     end
 
-    let :resource do
-      OpenStruct.new name: 'Stephen'
-    end
+    context "a registered resource" do
 
-    it "presents a single resource" do
-      presented = Jsonite.present resource, with: presenter
-      expect(presented).to eq "name"=>"Stephen"
-    end
+      let :presenter do
+        Class.new Jsonite do
+          property :name
+        end
+      end
 
-    it "presents an array of resources" do
-      presented = Jsonite.present [resource, resource], with: presenter
-      expect(presented).to eq [{"name"=>"Stephen"}, {"name"=>"Stephen"}]
-    end
+      let :resource do
+        OpenStruct.new name: 'Stephen'
+      end
 
-    it "defaults to using itself as presenter class" do
-      presented = presenter.present resource
-      expect(presented).to eq "name"=>"Stephen"
+      it "presents a single resource" do
+        presented = Jsonite.present resource, with: presenter
+        expect(presented).to eq "name"=>"Stephen"
+      end
+
+      it "presents an array of resources" do
+        presented = Jsonite.present [resource, resource], with: presenter
+        expect(presented).to eq [{"name"=>"Stephen"}, {"name"=>"Stephen"}]
+      end
+
+      it "defaults to using itself as presenter class" do
+        presented = presenter.present resource
+        expect(presented).to eq "name"=>"Stephen"
+      end
+
     end
 
   end

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -215,7 +215,7 @@ describe Jsonite do
 
     it "ignores nil properties with ignore_nil: true" do
       presenter = Class.new Jsonite do
-        property :name, ignore_nil: true
+        property :name, ignore: :nil?
       end
       presented = presenter.new OpenStruct.new
       json = presented.to_json
@@ -407,7 +407,7 @@ describe Jsonite do
 
     it "ignores nil embeds when ignore_nil: true" do
       user_presenter = Class.new Jsonite
-      user_presenter.embed :best_friend, with: user_presenter, ignore_nil: true
+      user_presenter.embed :best_friend, with: user_presenter, ignore: :nil?
       user = OpenStruct.new
       presented_user = user_presenter.present user
       json = presented_user.to_json

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -51,7 +51,7 @@ describe Jsonite do
 
   describe ".presents" do
 
-    before do
+    let! :presenter do
       Class.new(Jsonite(resource_class)) do
         property :name
       end
@@ -77,6 +77,32 @@ describe Jsonite do
       subclass = Class.new resource_class
       presented = Jsonite.present subclass.new name: 'Stephen', age: 30
       expect(presented).to eq "name"=>"Stephen"
+    end
+
+  end
+
+  describe ".resource_class" do
+
+    let! :presenter do
+      Class.new(Jsonite(resource_class)) do
+        property :name
+      end
+    end
+
+    let :resource_class do
+      Class.new OpenStruct
+    end
+
+    let :resource do
+      resource_class.new name: 'Stephen', age: 30
+    end
+
+    it "exposes the registered resource class for a given presenter" do
+      expect(presenter.resource_class).to eq resource_class
+    end
+
+    it "returns nil for a presenter without registered resource class" do
+      expect(Jsonite.resource_class).to be_nil
     end
 
   end

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -45,6 +45,65 @@ describe Jsonite do
         expect(presented).to eq :name=>"Stephen"
       end
 
+      context "root: true" do
+
+        it "wraps a single resource in a class-derived root key" do
+          presented = presenter.present resource, root: true
+          expect(presented).to eq "open_struct"=>{:name=>"Stephen"}
+        end
+
+        it "wraps an array of resources without a class-derivable root key" do
+          presented = presenter.present [resource, resource], root: true
+          expect(presented).to eq(
+            "array"=>[{:name=>"Stephen"}, {:name=>"Stephen"}]
+          )
+        end
+
+        context "nested relationship" do
+
+          it "does not wrap nested presentation" do
+            todo_presenter = Class.new Jsonite do
+              property :description
+            end
+            presenter.property :todos, with: todo_presenter
+            resource.todos = [OpenStruct.new(description: 'Buy milk')]
+            presented = presenter.present resource, root: true
+            expect(presented).to eq(
+              "open_struct"=>{
+                :name=>"Stephen", :todos=>[{:description=>'Buy milk'}]
+              }
+            )
+          end
+
+        end
+
+      end
+
+      context "root: String" do
+
+        it "wraps a single resource with the given root key" do
+          presented = presenter.present resource, root: 'user'
+          expect(presented).to eq "user"=>{:name=>"Stephen"}
+        end
+
+        it "wraps an array of resources with the given root key" do
+          presented = presenter.present [resource, resource], root: 'users'
+          expect(presented).to eq(
+            "users"=>[{:name=>"Stephen"}, {:name=>"Stephen"}]
+          )
+        end
+      end
+
+      context '.include_root_in_json' do
+
+        it 'wraps presentations in a root key derived from the resource class' do
+          Jsonite.stub include_root_in_json: true
+          presented = presenter.present resource
+          expect(presented).to eq "open_struct"=>{:name=>"Stephen"}
+        end
+
+      end
+
     end
 
   end

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -8,7 +8,7 @@ describe Jsonite do
     context "a hash" do
 
       let :resource do
-        {"name"=>"Stephen"}
+        {:name=>"Stephen"}
       end
 
       it "passes through unmodified" do
@@ -32,17 +32,17 @@ describe Jsonite do
 
       it "presents a single resource" do
         presented = Jsonite.present resource, with: presenter
-        expect(presented).to eq "name"=>"Stephen"
+        expect(presented).to eq :name=>"Stephen"
       end
 
       it "presents an array of resources" do
         presented = Jsonite.present [resource, resource], with: presenter
-        expect(presented).to eq [{"name"=>"Stephen"}, {"name"=>"Stephen"}]
+        expect(presented).to eq [{:name=>"Stephen"}, {:name=>"Stephen"}]
       end
 
       it "defaults to using itself as presenter class" do
         presented = presenter.present resource
-        expect(presented).to eq "name"=>"Stephen"
+        expect(presented).to eq :name=>"Stephen"
       end
 
     end
@@ -67,16 +67,16 @@ describe Jsonite do
 
     it "sets a default presenter for a given resource class" do
       presented = Jsonite.present resource
-      expect(presented).to eq "name"=>"Stephen"
+      expect(presented).to eq :name=>"Stephen"
 
       presented = Jsonite.present [resource, resource]
-      expect(presented).to eq [{"name"=>"Stephen"}, {"name"=>"Stephen"}]
+      expect(presented).to eq [{:name=>"Stephen"}, {:name=>"Stephen"}]
     end
 
     it "presents resource subclasses" do
       subclass = Class.new resource_class
       presented = Jsonite.present subclass.new name: 'Stephen', age: 30
-      expect(presented).to eq "name"=>"Stephen"
+      expect(presented).to eq :name=>"Stephen"
     end
 
   end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -7,7 +7,7 @@ Document = Struct.new(:name, :path, :content_type, :related_documents) do
   end
 end
 
-class DocumentPresenter < Jsonite
+class DocumentPresenter < Jsonite Document
   property :name
   property :path
   property :content_type
@@ -25,7 +25,7 @@ User = Struct.new(:name, :age, :friends, :documents) do
   end
 end
 
-class UserPresenter < Jsonite
+class UserPresenter < Jsonite User
   property :name
   property :age
   property(:location) { '37.788079, -122.401288' }


### PR DESCRIPTION
This removes the `:ignore_nil` option in favor of a more flexible `:ignore` option:

``` rb
class UserPresenter < Jsonite(User)
  property :email, ignore: :nil?
end
```

The one difference is that, unlike other blocks in Jsonite, the symbol/proc is executed by the property value, _not_ the resource. Other options:
1. If a symbol, just send directly to the property; if a proc, exec by resource?
2. Exec both by resource instead (makes `ignore: :nil?` not as easy, though)
