### PR TITLE
Fix plural roots with ActiveRecord >= 4.2.0

### DIFF
--- a/lib/jsonite.rb
+++ b/lib/jsonite.rb
@@ -33,7 +33,7 @@ class Jsonite
       presented = if resource.is_a? Jsonite
         resource.present options
       elsif resource.respond_to?(:to_ary)
-        resource = resource.to_ary.map do |member|
+        resource.to_ary.map do |member|
           presenter.new(member).present options.merge root: nil
         end
       else

--- a/lib/jsonite/helper.rb
+++ b/lib/jsonite/helper.rb
@@ -6,7 +6,7 @@ class Jsonite
     module_function
 
     def resource_name resource
-      if resource.respond_to? :model_name
+      if resource.respond_to?(:model_name) && resource.respond_to?(:to_ary)
         resource.model_name.collection
       elsif resource.class.respond_to? :model_name
         resource.class.model_name.singular

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -32,6 +32,48 @@ describe Jsonite do
 
   end
 
+  describe ":root" do
+    let :model do
+      Class.new do
+        include ActiveModel::Model
+        attr_accessor :name
+
+        def self.name
+          'User'
+        end
+      end
+    end
+
+    let :resource do
+      model.new name: 'Stephen'
+    end
+
+    let :relation do
+      [resource, resource].tap do |relation|
+        class << relation
+          def model_name() first.model_name end
+          def to_ary() self end
+        end
+      end
+    end
+
+    let :presenter do
+      Class.new Jsonite do
+        property :name
+      end
+    end
+
+    it "presents a singular resource with a singular root" do
+      presented = presenter.present resource
+      expect(presented).to eq "user"=>{"name"=>"Stephen"}
+    end
+
+    it "presents a collection with a plural root" do
+      presented = presenter.present relation
+      expect(presented).to eq "users"=>[{"name"=>"Stephen"},{"name"=>"Stephen"}]
+    end
+  end
+
   describe ".property" do
 
     it "exposes a specified attribute when presenting an object" do


### PR DESCRIPTION
In ActiveRecord 4.2.0, the `model_name` method was introduced to
instances of ActiveRecord::Base classes. Now that this is defined on
both individual records and collections, we need an additional check to
see whether we're dealing with one record or a collection. Considering
we use `respond_to? :to_ary` elsewhere, this patch duplicates that check
in `Helper.resource_name`.

Signed-off-by: David Celis <me@davidcel.is>