### PR TITLE
Add .let to define memoized "virtual" methods on presenter resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.0
+  - 2.1.5
+  - 2.2.2
 before_install:
   - gem install minitest -v '4.7.5' --no-document --quiet

--- a/lib/jsonite/lets_proxy.rb
+++ b/lib/jsonite/lets_proxy.rb
@@ -1,0 +1,23 @@
+class Jsonite
+  class LetsProxy < BasicObject
+
+    undef_method :==, :!, :!=
+
+    def initialize object, context, lets = {}
+      @__object, @__context, @__lets = object, context, lets
+
+      @__memoized = ::Hash.new do |memoized, name|
+        memoized[name] = instance_exec @__context, &@__lets.fetch(name)
+      end
+    end
+
+    def method_missing name, *args, &block
+      if @__lets.key?(name.to_s)
+        @__memoized[name.to_s]
+      else
+        @__object.__send__ name, *args, &block
+      end
+    end
+
+  end
+end

--- a/lib/jsonite/lets_proxy.rb
+++ b/lib/jsonite/lets_proxy.rb
@@ -4,18 +4,18 @@ class Jsonite
     undef_method :==, :!, :!=
 
     def initialize object, context, lets = {}
-      @__object, @__context, @__lets = object, context, lets
+      @__object__, @__context__, @__lets__ = object, context, lets
 
-      @__memoized = ::Hash.new do |memoized, name|
-        memoized[name] = instance_exec @__context, &@__lets.fetch(name)
+      @__memoized__ = ::Hash.new do |memoized, name|
+        memoized[name] = instance_exec @__context__, &@__lets__.fetch(name)
       end
     end
 
     def method_missing name, *args, &block
-      if @__lets.key?(name.to_s)
-        @__memoized[name.to_s]
+      if @__lets__.key?(name.to_s)
+        @__memoized__[name.to_s]
       else
-        @__object.__send__ name, *args, &block
+        @__object__.__send__ name, *args, &block
       end
     end
 

--- a/spec/jsonite_spec.rb
+++ b/spec/jsonite_spec.rb
@@ -326,4 +326,40 @@ describe Jsonite do
 
   end
 
+  describe ".let" do
+
+    it "defines a virtual resource method" do
+      user_presenter = Class.new Jsonite
+      user_presenter.let(:full_name) { "#{first_name} #{last_name}" }
+      user_presenter.property(:full_name)
+      user = OpenStruct.new first_name: "John", last_name: "Doe"
+      presented_user = user_presenter.present user
+      json = presented_user.to_json
+      expect(json).to eq '{"full_name":"John Doe"}'
+    end
+
+    it "provides the context as a block argument" do
+      user_presenter = Class.new Jsonite
+      user_presenter.let(:user_agent) { |ctx| ctx.user_agent }
+      user_presenter.property(:user_agent)
+      user = OpenStruct.new
+      ctx = OpenStruct.new(user_agent: "curl")
+      presented_user = user_presenter.present user, context: ctx
+      json = presented_user.to_json
+      expect(json).to eq '{"user_agent":"curl"}'
+    end
+
+    it "allows other lets to be called" do
+      user_presenter = Class.new Jsonite
+      user_presenter.let(:first_name) { "John" }
+      user_presenter.let(:last_name) { "Doe" }
+      user_presenter.let(:full_name) { "#{first_name} #{last_name}" }
+      user_presenter.property(:full_name)
+      user = OpenStruct.new
+      presented_user = user_presenter.present user
+      json = presented_user.to_json
+      expect(json).to eq '{"full_name":"John Doe"}'
+    end
+
+  end
 end


### PR DESCRIPTION
For some reason the .let and .lets methods were added in f312bc8, but they weren't implemented. This completes a basic implementation which defines "virtual" memoized methods on the resource.

- Efficient reuse of expensive values in multiple properties
- Cleans up model decorators even further

Example:

```rb
class UserPresenter < Jsonite
  let(:full_name) { "#{first_name} #{last_name}" }
  property :full_name
end
# {
#   "full_name": "Stephen Celis"
# }
```

Downsides:
- Third place where presentation methods are defined (context, resource, lets)